### PR TITLE
feat(stx): generate component declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ import { generate, processSource } from '@stacksjs/dtsx'
 const options: DtsGenerationOptions = {
   cwd: './', // default: process.cwd()
   root: './src', // default: './src'
-  entrypoints: ['**/*.ts'], // default: ['**/*.ts']
+  entrypoints: ['**/*.{ts,tsx,mts,cts,vue,stx}'], // default
   outdir: './dist', // default: './dist'
   clean: true, // default: false
   verbose: true, // default: false
@@ -79,6 +79,31 @@ console.log(dtsContent)
 // export declare const greeting: string;
 // export declare function greet(name: string): string;
 ```
+
+### STX Components
+
+`.stx` files are declaration entrypoints alongside TypeScript and Vue files.
+dtsx reads Vue-style `<script server|client>` blocks and Blade-style `@ts`
+blocks, then emits an `@stacksjs/stx` `DefineComponent` declaration. Props are
+derived from typed macros, runtime prop schemas, explicit `props as Props`
+assertions, and legacy `$props.name` access:
+
+```stx
+<script server lang="ts">
+interface CardProps {
+  title: string
+  count?: number
+}
+
+const props = withDefaults(defineProps<CardProps>(), { count: 0 })
+</script>
+
+<article>{{ props.title }}</article>
+```
+
+This emits `Card.d.ts` with `{ title: string; count?: number }` as its `$props`
+contract. The same transform feeds the semantic inference path and the
+annotation-first `isolatedDeclarations` path.
 
 Library usage can also be configured using a `dts.config.ts` _(or `dts.config.js`)_ file, automatically loaded when running `./dtsx` _(or `bunx dtsx`)_ and when calling `generate()` unless custom options are provided.
 
@@ -185,7 +210,7 @@ cat src/utils.ts | dtsx stdin > dist/utils.d.ts
 
 - `--cwd <path>`: Set the current working directory _(default: current directory)_
 - `--root <path>`: Specify the root directory of the project _(default: './src')_
-- `--entrypoints <files>`: Define entry point files _(comma-separated, default: '**/*.ts')_
+- `--entrypoints <files>`: Define entry point files _(comma-separated, default: `**/*.{ts,tsx,mts,cts,vue,stx}`)_
 - `--outdir <path>`: Set the output directory for generated .d.ts files _(default: './dist')_
 - `--keep-comments`: Keep comments in generated .d.ts files _(default: true)_
 - `--clean`: Clean output directory before generation _(default: false)_

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ import { generate } from '@stacksjs/dtsx'
 const config: DtsGenerationConfig = {
   cwd: './', // default: process.cwd()
   root: './src', // default: './src'
-  entrypoints: ['**/*.ts'], // default: ['**/*.ts']
+  entrypoints: ['**/*.{ts,tsx,mts,cts,vue,stx}'], // default
   outdir: './dist', // default: './dist'
   keepComments: true, // default: true
   clean: true, // default: true
@@ -134,7 +134,7 @@ dtsx generate --output-structure flat
 |--------|------|---------|-------------|
 | `--cwd <path>` | `string` | current directory | Set the current working directory |
 | `--root <path>` | `string` | `'./src'` | Specify the root directory of the project |
-| `--entrypoints <files>` | `string` | `'**/*.ts'` | Define entry point files (comma-separated) |
+| `--entrypoints <files>` | `string` | `'**/*.{ts,tsx,mts,cts,vue,stx}'` | Define entry point files (comma-separated) |
 | `--outdir <path>` | `string` | `'./dist'` | Set the output directory for generated .d.ts files |
 | `--keep-comments [value]` | `boolean` | `true` | Keep comments in generated .d.ts files |
 | `--clean` | `boolean` | `true` | Clean output directory before generation |

--- a/packages/dtsx/README.md
+++ b/packages/dtsx/README.md
@@ -64,7 +64,7 @@ import { generate } from '@stacksjs/dtsx'
 const options: DtsGenerationOptions = {
   cwd: './', // default: process.cwd()
   root: './src', // default: './src'
-  entrypoints: ['**/*.ts'], // default: ['**/*.ts']
+  entrypoints: ['**/*.{ts,tsx,mts,cts,vue,stx}'], // default
   outdir: './dist', // default: './dist'
   clean: true, // default: false
   verbose: true, // default: false
@@ -73,6 +73,13 @@ const options: DtsGenerationOptions = {
 
 await generate(options)
 ```
+
+### STX Components
+
+`.stx` entrypoints support Vue-style script blocks, Blade-style `@ts` blocks,
+typed and runtime `defineProps`, `props as Props`, and legacy `$props.name`
+contracts. dtsx emits the default component as
+`DefineComponent<Props>` from `@stacksjs/stx` in semantic and isolated modes.
 
 ### Configuration File
 
@@ -269,7 +276,7 @@ echo "export function foo(): string { return 'bar' }" | dtsx stdin
 #### Generate Options
 
 - `--root <path>`: Specify the root directory of the project _(default: './src')_
-- `--entrypoints <files>`: Define entry point files _(comma-separated, default: '**/*.ts')_
+- `--entrypoints <files>`: Define entry point files _(comma-separated, default: `**/*.{ts,tsx,mts,cts,vue,stx}`)_
 - `--outdir <path>`: Set the output directory for generated .d.ts files _(default: './dist')_
 - `--keep-comments`: Keep comments in generated .d.ts files _(default: true)_
 - `--clean`: Clean output directory before generation _(default: false)_

--- a/packages/dtsx/src/config.ts
+++ b/packages/dtsx/src/config.ts
@@ -9,7 +9,7 @@ import { logger } from './logger'
 export const defaultConfig: DtsGenerationConfig = {
   cwd: process.cwd(),
   root: './src',
-  entrypoints: ['**/*.{ts,tsx,mts,cts}'],
+  entrypoints: ['**/*.{ts,tsx,mts,cts,vue,stx}'],
   outdir: './dist',
   keepComments: true,
   clean: true,

--- a/packages/dtsx/src/extractor/extract.ts
+++ b/packages/dtsx/src/extractor/extract.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Declaration } from '../types'
+import { isStxFile, transformStxToTs } from '../stx'
 import { isVueFile, transformVueSfcToTs } from '../vue'
 import { hashContent } from './hash'
 import { scanIsolatedDeclarations, scanSemanticDeclarations } from './scanner'
@@ -23,9 +24,12 @@ export function extractDeclarations(
   keepComments: boolean = true,
   isolatedDeclarations: boolean = false,
 ): Declaration[] {
-  // Vue SFCs are transformed into a virtual TS module before scanning.
+  // Component files are transformed into virtual TS modules before scanning.
   if (isVueFile(filePath)) {
     sourceCode = transformVueSfcToTs(sourceCode)
+  }
+  else if (isStxFile(filePath)) {
+    sourceCode = transformStxToTs(sourceCode)
   }
 
   const contentHash = hashContent(sourceCode)

--- a/packages/dtsx/src/generator.ts
+++ b/packages/dtsx/src/generator.ts
@@ -792,7 +792,7 @@ function assertUniqueOutputPaths(files: string[], config: DtsGenerationConfig): 
 }
 
 function isProcessableSourceFile(filePath: string): boolean {
-  return /\.(m?tsx?|cts|jsx?|mjs|cjs|vue)$/.test(filePath) && !/\.d\.(?:ts|mts|cts)$/.test(filePath)
+  return /\.(m?tsx?|cts|jsx?|mjs|cjs|vue|stx)$/.test(filePath) && !/\.d\.(?:ts|mts|cts)$/.test(filePath)
 }
 
 /**
@@ -801,7 +801,7 @@ function isProcessableSourceFile(filePath: string): boolean {
 function getOutputPath(inputPath: string, config: DtsGenerationConfig): string {
   const rootPath = resolve(config.cwd, config.root)
   const relativePath = relative(rootPath, inputPath)
-  const dtsPath = relativePath.replace(/\.(m?tsx?|cts|jsx?|mjs|cjs|vue)$/, (ext) => {
+  const dtsPath = relativePath.replace(/\.(m?tsx?|cts|jsx?|mjs|cjs|vue|stx)$/, (ext) => {
     if (ext === '.mts' || ext === '.mjs') return '.d.mts'
     if (ext === '.cts' || ext === '.cjs') return '.d.cts'
     return '.d.ts'
@@ -1125,7 +1125,7 @@ export async function watch(options?: Partial<DtsGenerationConfig>): Promise<voi
     const rootPath = '${rootPath}';
 
     fs.watch(rootPath, { recursive: true }, (eventType, filename) => {
-      if (filename && filename.endsWith('.ts') && !filename.endsWith('.d.ts')) {
+      if (filename && /\.(?:[cm]?[jt]sx?|vue|stx)$/.test(filename) && !/\.d\.(?:ts|mts|cts)$/.test(filename)) {
         console.log(\`CHANGED:\${filename}\`);
       }
     });

--- a/packages/dtsx/src/module-graph.ts
+++ b/packages/dtsx/src/module-graph.ts
@@ -42,7 +42,7 @@ export interface ResolveResult {
  * Extensions tried, in order, when resolving an extensionless specifier.
  * `.d.ts` last so source files win over generated declarations.
  */
-const TS_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs', '.d.ts', '.d.mts', '.d.cts'] as const
+const TS_EXTENSIONS = ['.ts', '.tsx', '.mts', '.cts', '.vue', '.stx', '.js', '.jsx', '.mjs', '.cjs', '.d.ts', '.d.mts', '.d.cts'] as const
 
 const RUNTIME_SOURCE_EXTENSIONS: Readonly<Record<string, readonly string[]>> = {
   '.js': ['.ts', '.tsx', '.d.ts'],

--- a/packages/dtsx/src/process-source.ts
+++ b/packages/dtsx/src/process-source.ts
@@ -3,6 +3,7 @@ import { extractDeclarations } from './extractor/extract'
 import { hashContent } from './extractor/hash'
 import { scanIsolatedDeclarations, scanSemanticDeclarations } from './extractor/scanner'
 import { processDeclarations } from './processor'
+import { isStxFile, transformStxToTs } from './stx'
 import { isVueFile, transformVueSfcToTs } from './vue'
 
 // ---------------------------------------------------------------------------
@@ -102,9 +103,12 @@ export function processSourceDirect(
   importOrder: string[] = ['bun'],
   isolatedDeclarations: boolean = false,
 ): string {
-  // Vue SFCs are transformed into a virtual TS module before scanning.
+  // Component files are transformed into virtual TS modules before scanning.
   if (isVueFile(filename)) {
     sourceCode = transformVueSfcToTs(sourceCode)
+  }
+  else if (isStxFile(filename)) {
+    sourceCode = transformStxToTs(sourceCode)
   }
   const declarations = isolatedDeclarations
     ? scanIsolatedDeclarations(sourceCode, filename, keepComments)

--- a/packages/dtsx/src/stx.ts
+++ b/packages/dtsx/src/stx.ts
@@ -1,0 +1,297 @@
+/**
+ * STX single-file component declaration support.
+ *
+ * STX accepts Vue-style `<script>` blocks and Laravel Blade-style `@ts`
+ * blocks. Both forms are collected into one virtual TypeScript module before
+ * the normal semantic or isolated declaration scanner runs.
+ */
+
+import {
+  collapseTypeText,
+  extractDefaultExportOptions,
+  filterLocalValueStatements,
+  findMacroCall,
+  findMatching,
+  getOptionValue,
+  mapRuntimeProps,
+  maskNonCode,
+  removeInlinedDeclaration,
+  resolveEmitsType,
+  resolveExposedType,
+  resolvePropsType,
+  skipNonCode,
+  stripMacroStatements,
+  type PropsResolution,
+} from './vue'
+
+export interface StxScriptBlock {
+  /** TypeScript or JavaScript source contained by the block. */
+  content: string
+  /** Source syntax used to declare the block. */
+  kind: 'script' | 'ts'
+  /** Raw attributes for `<script>` blocks. */
+  attrs: string
+  /** Whether the block runs on the server, client, or in either context. */
+  context: 'server' | 'client' | 'universal'
+  /** Declared script language, lowercased. */
+  lang: string
+  /** Byte offset of the block's opening delimiter. */
+  start: number
+}
+
+/** Check whether a file path points at an STX component. */
+export function isStxFile(filePath: string): boolean {
+  return filePath.endsWith('.stx')
+}
+
+function parseScriptBlocks(source: string): StxScriptBlock[] {
+  const blocks: StxScriptBlock[] = []
+  const scriptTag = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = scriptTag.exec(source)) !== null) {
+    const attrs = match[1] ?? ''
+    const lang = /\blang\s*=\s*["']([^"']+)["']/i.exec(attrs)?.[1]?.toLowerCase()
+      ?? (/\b(?:type\s*=\s*["'](?:text\/)?typescript["']|typescript)\b/i.test(attrs) ? 'ts' : 'js')
+    const context = /\bserver\b/i.test(attrs)
+      ? 'server'
+      : /\bclient\b/i.test(attrs) ? 'client' : 'universal'
+    blocks.push({
+      content: match[2] ?? '',
+      kind: 'script',
+      attrs,
+      context,
+      lang,
+      start: match.index,
+    })
+  }
+  return blocks
+}
+
+/**
+ * Parse Blade-style `@ts` blocks. Delimiters are recognized only when they
+ * occupy a line, preventing `"@endts"` inside TypeScript strings and comments
+ * from truncating the block. An unclosed block extends to end-of-file so a
+ * partially edited component still yields the declarations written so far.
+ */
+function parseTsBlocks(source: string): StxScriptBlock[] {
+  const blocks: StxScriptBlock[] = []
+  const opener = /^[ \t]*@ts[ \t]*(?:\r?\n|$)/gm
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = opener.exec(source)) !== null) {
+    const contentStart = opener.lastIndex
+    const closer = /^[ \t]*@endts[ \t]*(?:\r?\n|$)/gm
+    closer.lastIndex = contentStart
+    const close = closer.exec(source)
+    const contentEnd = close?.index ?? source.length
+    blocks.push({
+      content: source.slice(contentStart, contentEnd),
+      kind: 'ts',
+      attrs: '',
+      context: 'universal',
+      lang: 'ts',
+      start: match.index,
+    })
+    if (!close) break
+    opener.lastIndex = closer.lastIndex
+  }
+  return blocks
+}
+
+/** Collect all declaration-bearing STX blocks in document order. */
+export function parseStxScripts(source: string): StxScriptBlock[] {
+  return [...parseScriptBlocks(source), ...parseTsBlocks(source)]
+    .sort((left, right) => left.start - right.start)
+}
+
+function isDeclarationBearingBlock(block: StxScriptBlock): boolean {
+  if (block.kind === 'ts' || block.context !== 'universal' || block.lang === 'ts') return true
+  // A plain HTML `<script>` commonly contains page bootstrap code rather than
+  // component authoring state. Keep it only when it carries a public or typed
+  // declaration signal; template-only runtime code cannot affect a `.d.ts`.
+  return /\b(?:defineProps|defineEmits|defineExpose|defineSlots)\b|\bexport\s|\b(?:interface|type)\s+[A-Za-z_$]/.test(block.content)
+}
+
+function findPropsAssertion(script: string): string | null {
+  const assertion = /(?:\$?props)\s+as\s+/g
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = assertion.exec(script)) !== null) {
+    let start = assertion.lastIndex
+    while (start < script.length && /\s/.test(script[start])) start++
+    if (script[start] === '{') {
+      const end = findMatching(script, start, '{', '}')
+      if (end !== -1) return script.slice(start, end + 1).trim()
+      continue
+    }
+    const name = /^[A-Za-z_$][\w$]*/.exec(script.slice(start))?.[0]
+    if (!name) continue
+    let end = start + name.length
+    while (end < script.length && /\s/.test(script[end])) end++
+    if (script[end] === '<') {
+      const genericEnd = findMatching(script, end, '<', '>')
+      if (genericEnd !== -1) end = genericEnd + 1
+    }
+    return script.slice(start, end).trim()
+  }
+  return null
+}
+
+function findPropsAnnotation(script: string): string | null {
+  const match = /\b(?:const|let|var)\s+\$?props\s*:\s*([^=;\n]+)/.exec(script)
+  return match?.[1]?.trim() ?? null
+}
+
+function inferAmbientPropType(codeAfterAccess: string): string {
+  const value = /^\s*(?:\|\||\?\?)\s*([^;\n]+)/.exec(codeAfterAccess)?.[1]?.trim()
+  if (/^['"`]/.test(value ?? '')) return 'string'
+  if (/^(?:true|false)\b/.test(value ?? '')) return 'boolean'
+  if (/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)\b/.test(value ?? '')) return 'number'
+  if (/^\[/.test(value ?? '')) return 'unknown[]'
+  if (/^\{/.test(value ?? '')) return 'Record<string, unknown>'
+  if (/^\s*(?:===?|!==?)\s*(?:true|false)\b/.test(codeAfterAccess)) return 'boolean'
+  return 'unknown'
+}
+
+function mergeAmbientPropType(previous: string | undefined, next: string): string {
+  if (!previous || previous === 'unknown') return next
+  if (next === 'unknown' || previous === next) return previous
+  const members = new Set([...previous.split(' | '), ...next.split(' | ')])
+  return [...members].join(' | ')
+}
+
+/** Infer the legacy `$props.name` STX contract used throughout component libraries. */
+function resolveAmbientProps(script: string): PropsResolution | null {
+  const code = maskNonCode(script)
+  const props = new Map<string, string>()
+  const access = /\$props(?:\.([A-Za-z_$][\w$]*)|\[\s*(['"])([^'"\n]+)\2\s*\])/g
+  let match: RegExpExecArray | null
+  // eslint-disable-next-line no-cond-assign
+  while ((match = access.exec(script)) !== null) {
+    if (code.slice(match.index, match.index + 6) !== '$props') continue
+    const name = match[1] ?? match[3]
+    const inferred = inferAmbientPropType(script.slice(access.lastIndex))
+    props.set(name, mergeAmbientPropType(props.get(name), inferred))
+  }
+  if (props.size === 0) return null
+  const members = [...props].map(([name, type]) => {
+    const key = /^[A-Za-z_$][\w$]*$/.test(name) ? name : JSON.stringify(name)
+    return `${key}?: ${type}`
+  })
+  return { type: `{ ${members.join(', ')} }` }
+}
+
+function resolveStxProps(script: string): PropsResolution | null {
+  const macroProps = resolvePropsType(script, null)
+  if (macroProps) return macroProps
+
+  const assertedType = findPropsAssertion(script) ?? findPropsAnnotation(script)
+  if (!assertedType) return resolveAmbientProps(script)
+
+  if (/^[A-Za-z_$][\w$]*$/.test(assertedType)) {
+    const escaped = assertedType.replace(/[$]/g, '\\$&')
+    const exportedType = new RegExp(`\\bexport\\s+(?:declare\\s+)?(?:interface|type)\\s+${escaped}\\b`)
+    if (exportedType.test(script)) return { type: assertedType }
+  }
+
+  // Reuse the SFC resolver so local interfaces and aliases are inlined while
+  // imported or compound type references remain intact.
+  return resolvePropsType(`${script}\ndefineProps<${assertedType}>()`, null)
+}
+
+function stripStxCompilerStatements(content: string): string {
+  return stripMacroStatements(content)
+}
+
+function isDeclarationStatement(statement: string): boolean {
+  const code = maskNonCode(statement).trimStart()
+  if (code === '') return true
+  return /^(?:import\b|export\b|declare\b|interface\b|type\b|(?:export\s+)?namespace\b|(?:export\s+)?module\b|(?:abstract\s+)?class\b|const\b|let\b|var\b|(?:async\s+)?function\b)/.test(code)
+}
+
+/** Drop top-level browser/runtime statements that cannot contribute declarations. */
+function filterTopLevelRuntimeStatements(content: string): string {
+  const ranges: Array<[number, number]> = []
+  let start = 0
+  let depth = 0
+  let i = 0
+  while (i < content.length) {
+    const ch = content[i]
+    const nonCodeEnd = skipNonCode(content, i)
+    if (nonCodeEnd > i) {
+      i = nonCodeEnd
+      continue
+    }
+    if (ch === '{' || ch === '[' || ch === '(') depth++
+    else if (ch === '}' || ch === ']' || ch === ')') depth = Math.max(0, depth - 1)
+    if ((ch === ';' || ch === '\n') && depth === 0) {
+      const end = i + 1
+      if (!isDeclarationStatement(content.slice(start, end))) ranges.push([start, end])
+      start = end
+    }
+    i++
+  }
+  if (start < content.length && !isDeclarationStatement(content.slice(start))) ranges.push([start, content.length])
+  let result = content
+  for (let j = ranges.length - 1; j >= 0; j--) {
+    result = result.slice(0, ranges[j][0]) + result.slice(ranges[j][1])
+  }
+  return result
+}
+
+/**
+ * Transform an STX component into a virtual TypeScript module.
+ *
+ * The output deliberately imports STX's own Vue-compatible `DefineComponent`
+ * type. This makes generated declarations consumable without a Vue dependency
+ * and exposes `$props` to STX's component utility types and call-site tooling.
+ */
+export function transformStxToTs(source: string): string {
+  const blocks = parseStxScripts(source).filter(isDeclarationBearingBlock)
+  let scriptContent = blocks.map(block => block.content).join('\n')
+  let optionsProps: string | null = null
+
+  const extraction = extractDefaultExportOptions(scriptContent)
+  if (extraction.passthrough) return scriptContent
+  scriptContent = extraction.script
+  if (extraction.options) {
+    const propsOption = getOptionValue(extraction.options, 'props')
+    if (propsOption) optionsProps = mapRuntimeProps(propsOption)
+  }
+
+  const rawScript = scriptContent
+  let filteredScript = stripStxCompilerStatements(scriptContent)
+  const propsResolution = resolveStxProps(rawScript)
+  const props = propsResolution?.type ?? optionsProps ?? '{}'
+  const emits = resolveEmitsType(rawScript, null)
+  const exposed = resolveExposedType(rawScript, null)
+  const slots = findMacroCall(rawScript, 'defineSlots')?.generic ?? null
+
+  const inlined = propsResolution?.inlinedLocal
+  if (inlined) {
+    filteredScript = removeInlinedDeclaration(filteredScript, inlined.name, inlined.declText)
+  }
+
+  let componentType = `DefineComponent<${props}>`
+  const metadata: string[] = []
+  if (emits) metadata.push(`readonly __stxEmits?: ${emits}`)
+  if (slots) metadata.push(`readonly __stxSlots?: ${slots}`)
+  if (exposed) metadata.push(`readonly __stxExposed?: ${exposed}`)
+  if (metadata.length > 0) componentType += ` & { ${metadata.join(', ')} }`
+  componentType = collapseTypeText(componentType)
+
+  filteredScript = filterTopLevelRuntimeStatements(filterLocalValueStatements(filteredScript, componentType))
+  // Put the synthesized public surface first. Some legal STX client scripts
+  // start with browser-only expression statements (IIFEs, DOM registration),
+  // which intentionally are not declaration syntax and may stop a lightweight
+  // declaration scan before later statements.
+  const parts = [
+    `import type { DefineComponent } from '@stacksjs/stx'`,
+    `type __DtsxStxComponentType = ${componentType}`,
+    'const __dtsx_component__: __DtsxStxComponentType = null as unknown as __DtsxStxComponentType',
+    'export default __dtsx_component__',
+  ]
+  if (filteredScript.trim() !== '') parts.push(filteredScript)
+  return parts.join('\n')
+}

--- a/packages/dtsx/src/vue.ts
+++ b/packages/dtsx/src/vue.ts
@@ -125,6 +125,33 @@ function skipComment(text: string, i: number): number {
   return i + 1
 }
 
+/** Return the end of a string/template/comment at `i`, or `i` for normal code. */
+export function skipNonCode(text: string, i: number): number {
+  const ch = text[i]
+  if (ch === '"' || ch === '\'') return skipString(text, i)
+  if (ch === '`') return skipTemplate(text, i)
+  if (ch === '/' && (text[i + 1] === '/' || text[i + 1] === '*')) return skipComment(text, i)
+  return i
+}
+
+/** Replace strings, template literals and comments with spaces, preserving offsets and newlines. */
+export function maskNonCode(text: string): string {
+  const chars = text.split('')
+  let i = 0
+  while (i < text.length) {
+    const end = skipNonCode(text, i)
+    if (end > i) {
+      for (let j = i; j < end; j++) {
+        if (chars[j] !== '\n' && chars[j] !== '\r') chars[j] = ' '
+      }
+      i = end
+      continue
+    }
+    i++
+  }
+  return chars.join('')
+}
+
 /**
  * Find the index of the closer matching the opener at `start`
  * (`text[start]` must be the opener). Returns -1 when unbalanced.
@@ -303,7 +330,7 @@ function typeKey(key: string): string {
 // Compiler-macro extraction (defineProps / defineEmits / defineExpose)
 // ---------------------------------------------------------------------------
 
-interface MacroCall {
+export interface MacroCall {
   /** Generic type argument text (`defineProps<T>`), when present. */
   generic: string | null
   /** First argument text, when the call has arguments. */
@@ -311,7 +338,7 @@ interface MacroCall {
 }
 
 /** Locate the first `name(...)` / `name<T>(...)` call in `text`. */
-function findMacroCall(text: string, name: string): MacroCall | null {
+export function findMacroCall(text: string, name: string): MacroCall | null {
   const pattern = new RegExp(`\\b${name}\\b`, 'g')
   let match: RegExpExecArray | null
   // eslint-disable-next-line no-cond-assign
@@ -599,7 +626,8 @@ function convertEmitsCallSignatures(typeText: string): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Remove `defineProps` / `defineEmits` / `defineExpose` / `defineOptions`
+ * Remove `defineProps` / `defineEmits` / `defineExpose` / `defineSlots` /
+ * `defineOptions`
  * statements (including `withDefaults(defineProps(), ...)` wrappers) from
  * `<script setup>` content. Their type information has already been captured
  * in the synthesized component type; keeping the calls would only add noise
@@ -608,7 +636,7 @@ function convertEmitsCallSignatures(typeText: string): string | null {
  */
 export function stripMacroStatements(content: string): string {
   let result = content
-  for (const name of ['defineProps', 'defineEmits', 'defineExpose', 'defineOptions']) {
+  for (const name of ['defineProps', 'defineEmits', 'defineExpose', 'defineSlots', 'defineOptions']) {
     result = stripMacro(result, name)
   }
   return result
@@ -668,7 +696,7 @@ function stripMacro(text: string, name: string): string {
 // Options API default-export extraction
 // ---------------------------------------------------------------------------
 
-interface OptionsExtraction {
+export interface OptionsExtraction {
   /** The options object literal text, when a component options object was found. */
   options: string | null
   /** The script with the default export removed (kept only when options were found). */
@@ -679,11 +707,11 @@ interface OptionsExtraction {
 
 /** Extract the options object from `export default {...}` / `export default defineComponent({...})`. */
 export function extractDefaultExportOptions(script: string): OptionsExtraction {
-  const pattern = /\bexport\s+default\b/g
-  let match: RegExpExecArray | null
-  // eslint-disable-next-line no-cond-assign
-  while ((match = pattern.exec(script)) !== null) {
-    let i = match.index + match[0].length
+  const exportIndex = findTopLevelExportDefault(script)
+  if (exportIndex !== -1) {
+    const exportText = /^export\s+default\b/.exec(script.slice(exportIndex))?.[0]
+    if (!exportText) return { options: null, script, passthrough: false }
+    let i = exportIndex + exportText.length
     while (i < script.length && /\s/.test(script[i])) i++
 
     let objectStart = -1
@@ -716,14 +744,47 @@ export function extractDefaultExportOptions(script: string): OptionsExtraction {
 
     let end = statementEnd + 1
     if (script[end] === ';') end++
-    const cleaned = (script.slice(0, match.index) + script.slice(end)).trim()
+    const cleaned = (script.slice(0, exportIndex) + script.slice(end)).trim()
     return { options: script.slice(objectStart, objectEnd + 1), script: cleaned, passthrough: false }
   }
   return { options: null, script, passthrough: false }
 }
 
+/** Find a top-level `export default` outside strings, templates and comments. */
+function findTopLevelExportDefault(script: string): number {
+  let depth = 0
+  let i = 0
+  while (i < script.length) {
+    const ch = script[i]
+    if (ch === '"' || ch === '\'') {
+      i = skipString(script, i)
+      continue
+    }
+    if (ch === '`') {
+      i = skipTemplate(script, i)
+      continue
+    }
+    if (ch === '/' && (script[i + 1] === '/' || script[i + 1] === '*')) {
+      i = skipComment(script, i)
+      continue
+    }
+    if (ch === '{' || ch === '[' || ch === '(') depth++
+    else if (ch === '}' || ch === ']' || ch === ')') depth = Math.max(0, depth - 1)
+    else if (depth === 0 && script.startsWith('export', i)) {
+      const before = i === 0 ? '' : script[i - 1]
+      const after = script[i + 6] ?? ''
+      if (!/[\w$]/.test(before) && !/[\w$]/.test(after)) {
+        const match = /^export\s+default\b/.exec(script.slice(i))
+        if (match) return i
+      }
+    }
+    i++
+  }
+  return -1
+}
+
 /** Pull a named option (`props`, `emits`) out of an options object literal. */
-function getOptionValue(options: string, name: string): string | null {
+export function getOptionValue(options: string, name: string): string | null {
   const entry = parseObjectEntries(options).find(e => e.key === name)
   return entry && entry.value !== '' ? entry.value : null
 }
@@ -741,18 +802,47 @@ function getOptionValue(options: string, name: string): string | null {
  * source or in the synthesized component type (e.g. via `typeof sizes`) are
  * kept, as are exported declarations.
  */
-function filterLocalValueStatements(content: string, componentType: string): string {
+export function filterLocalValueStatements(content: string, componentType: string): string {
   const spans = findLocalValueStatements(content)
   // Remove from the end backwards so earlier spans stay valid.
   let result = content
   for (let i = spans.length - 1; i >= 0; i--) {
     const span = spans[i]
     const rest = result.slice(0, span.start) + result.slice(span.end)
-    if (new RegExp(`\\b${span.name}\\b`).test(rest)) continue
+    if (containsIdentifierReference(rest, span.name)) continue
     if (new RegExp(`\\btypeof\\s+${span.name}\\b`).test(componentType)) continue
     result = rest
   }
   return result
+}
+
+/** Check for an identifier outside strings and comments. */
+function containsIdentifierReference(content: string, name: string): boolean {
+  let i = 0
+  while (i < content.length) {
+    const ch = content[i]
+    if (ch === '"' || ch === '\'') {
+      i = skipString(content, i)
+      continue
+    }
+    if (ch === '`') {
+      i = skipTemplate(content, i)
+      continue
+    }
+    if (ch === '/' && (content[i + 1] === '/' || content[i + 1] === '*')) {
+      i = skipComment(content, i)
+      continue
+    }
+    if (/[A-Za-z_$]/.test(ch)) {
+      let end = i + 1
+      while (end < content.length && /[\w$]/.test(content[end])) end++
+      if (content.slice(i, end) === name) return true
+      i = end
+      continue
+    }
+    i++
+  }
+  return false
 }
 
 interface LocalValueStatement {
@@ -769,12 +859,14 @@ interface LocalValueStatement {
  */
 function findLocalValueStatements(content: string): LocalValueStatement[] {
   const spans: LocalValueStatement[] = []
+  const topLevelLineStarts = findTopLevelLineStarts(content)
   const pattern = /^[ \t]*(const|let|var|(?:async[ \t]+)?function)[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?::[^=\n]+)?=?/gm
   let match: RegExpExecArray | null
   // eslint-disable-next-line no-cond-assign
   while ((match = pattern.exec(content)) !== null) {
     // Never touch exported declarations.
     const lineStart = content.lastIndexOf('\n', match.index) + 1
+    if (!topLevelLineStarts.has(lineStart)) continue
     if (/\bexport\b/.test(content.slice(lineStart, match.index))) continue
 
     const keyword = match[1]
@@ -839,11 +931,38 @@ function findLocalValueStatements(content: string): LocalValueStatement[] {
   return spans
 }
 
+/** Collect line starts whose code is outside every brace/paren/bracket pair. */
+function findTopLevelLineStarts(content: string): Set<number> {
+  const starts = new Set<number>([0])
+  let depth = 0
+  let i = 0
+  while (i < content.length) {
+    const ch = content[i]
+    if (ch === '"' || ch === '\'') {
+      i = skipString(content, i)
+      continue
+    }
+    if (ch === '`') {
+      i = skipTemplate(content, i)
+      continue
+    }
+    if (ch === '/' && (content[i + 1] === '/' || content[i + 1] === '*')) {
+      i = skipComment(content, i)
+      continue
+    }
+    if (ch === '{' || ch === '[' || ch === '(') depth++
+    else if (ch === '}' || ch === ']' || ch === ')') depth = Math.max(0, depth - 1)
+    if (ch === '\n' && depth === 0) starts.add(i + 1)
+    i++
+  }
+  return starts
+}
+
 /**
  * Remove an inlined interface/alias declaration from script content, unless
  * the name is still referenced elsewhere or the declaration is exported.
  */
-function removeInlinedDeclaration(content: string, name: string, declText: string): string {
+export function removeInlinedDeclaration(content: string, name: string, declText: string): string {
   const index = content.indexOf(declText)
   if (index === -1) return content
   // Never remove exported declarations — they are part of the module API.
@@ -855,7 +974,7 @@ function removeInlinedDeclaration(content: string, name: string, declText: strin
   return rest
 }
 
-interface PropsResolution {
+export interface PropsResolution {
   type: string
   /** A local interface/alias that was inlined into the props type. */
   inlinedLocal?: { name: string, declText: string }
@@ -866,7 +985,7 @@ interface PropsResolution {
  * literal members become `;`, continuation newlines (after an opener, comma,
  * colon, or before a closer, comma, union/intersection bar) become spaces.
  */
-function collapseTypeText(text: string): string {
+export function collapseTypeText(text: string): string {
   let out = ''
   let i = 0
   const prevSignificant = (): string => {
@@ -962,7 +1081,7 @@ function endsWithLeadingComment(out: string): boolean {
   return true
 }
 
-function resolvePropsType(scriptSetup: string | null, script: string | null): PropsResolution | null {
+export function resolvePropsType(scriptSetup: string | null, script: string | null): PropsResolution | null {
   const sources = [scriptSetup, script].filter((s): s is string => s !== null)
   for (const source of sources) {
     const call = findMacroCall(source, 'defineProps')
@@ -993,7 +1112,7 @@ function resolvePropsType(scriptSetup: string | null, script: string | null): Pr
   return null
 }
 
-function resolveEmitsType(scriptSetup: string | null, script: string | null): string | null {
+export function resolveEmitsType(scriptSetup: string | null, script: string | null): string | null {
   const sources = [scriptSetup, script].filter((s): s is string => s !== null)
   for (const source of sources) {
     const call = findMacroCall(source, 'defineEmits')
@@ -1012,7 +1131,7 @@ function resolveEmitsType(scriptSetup: string | null, script: string | null): st
   return null
 }
 
-function resolveExposedType(scriptSetup: string | null, script: string | null): string | null {
+export function resolveExposedType(scriptSetup: string | null, script: string | null): string | null {
   const sources = [scriptSetup, script].filter((s): s is string => s !== null)
   for (const source of sources) {
     const call = findMacroCall(source, 'defineExpose')
@@ -1020,6 +1139,9 @@ function resolveExposedType(scriptSetup: string | null, script: string | null): 
     const entries = parseObjectEntries(call.arg)
     if (entries.length === 0) return null
     const props = entries.map((entry) => {
+      if (entry.value === '' && /^[A-Za-z_$][\w$]*$/.test(entry.key)) {
+        return `${typeKey(entry.key)}: typeof ${entry.key}`
+      }
       const isFunction = entry.isMethod || /=>|^\s*function\b/.test(entry.value)
       return `${typeKey(entry.key)}: ${isFunction ? '(...args: any[]) => any' : 'unknown'}`
     })

--- a/packages/dtsx/src/watcher.ts
+++ b/packages/dtsx/src/watcher.ts
@@ -19,7 +19,7 @@ export interface WatchConfig {
 
   /**
    * File patterns to watch (glob-like)
-   * @default ['**\/*.ts', '**\/*.tsx']
+   * @default ['**\/*.ts', '**\/*.tsx', '**\/*.vue', '**\/*.stx']
    */
   include?: string[]
 
@@ -126,7 +126,7 @@ export function createWatcher(
 ): Watcher {
   const {
     root,
-    include = ['**/*.ts', '**/*.tsx'],
+    include = ['**/*.ts', '**/*.tsx', '**/*.vue', '**/*.stx'],
     exclude = ['**/node_modules/**', '**/*.d.ts', '**/dist/**'],
     debounce = 100,
     initialBuild = true,

--- a/packages/dtsx/test/config.test.ts
+++ b/packages/dtsx/test/config.test.ts
@@ -20,8 +20,8 @@ async function createProject(name: string): Promise<string> {
 }
 
 describe('getConfig', () => {
-  it('discovers every TypeScript module source format by default', () => {
-    expect(defaultConfig.entrypoints).toEqual(['**/*.{ts,tsx,mts,cts}'])
+  it('discovers supported module and component source formats by default', () => {
+    expect(defaultConfig.entrypoints).toEqual(['**/*.{ts,tsx,mts,cts,vue,stx}'])
   })
 
   it('isolates cached configuration by project directory', async () => {

--- a/packages/dtsx/test/fixtures/stx/BladeAlert.stx
+++ b/packages/dtsx/test/fixtures/stx/BladeAlert.stx
@@ -1,0 +1,18 @@
+{{-- This is the same typed-props convention used by STX's Blade examples. --}}
+@ts
+export interface AlertProps {
+  type: 'success' | 'info' | 'warning' | 'error'
+  message: string
+  dismissible?: boolean
+}
+
+const { type, message, dismissible = false } = props as AlertProps
+const getAlertClass = () => `alert-${type}`
+@endts
+
+<div class="alert {{ getAlertClass() }}">
+  <p>{{ message }}</p>
+  @if(dismissible)
+    <button>Close</button>
+  @endif
+</div>

--- a/packages/dtsx/test/fixtures/stx/MixedBlocks.stx
+++ b/packages/dtsx/test/fixtures/stx/MixedBlocks.stx
@@ -1,0 +1,16 @@
+@ts
+export type ServerStatus = 'ready' | 'busy'
+export const STATUS_ATTRIBUTE = 'data-status' as const
+@endts
+
+<script client lang="ts">
+interface Props {
+  status: ServerStatus
+  retries?: number
+}
+
+const props = defineProps<Props>()
+const retries = state(props.retries ?? 0)
+</script>
+
+<div data-status="{{ props.status }}">{{ retries }}</div>

--- a/packages/dtsx/test/fixtures/stx/OptionsBadge.stx
+++ b/packages/dtsx/test/fixtures/stx/OptionsBadge.stx
@@ -1,0 +1,14 @@
+<script lang="ts">
+import type { BadgeMeta } from './types'
+
+export default {
+  props: {
+    label: { type: String, required: true },
+    count: Number,
+    active: Boolean,
+    meta: Object as PropType<BadgeMeta>,
+  },
+}
+</script>
+
+<span>{{ label }}</span>

--- a/packages/dtsx/test/fixtures/stx/TemplateOnly.stx
+++ b/packages/dtsx/test/fixtures/stx/TemplateOnly.stx
@@ -1,0 +1,3 @@
+<article>
+  <slot></slot>
+</article>

--- a/packages/dtsx/test/fixtures/stx/TypedPanel.stx
+++ b/packages/dtsx/test/fixtures/stx/TypedPanel.stx
@@ -1,0 +1,36 @@
+<script server lang="ts">
+import type { PanelTone } from './types'
+
+export const PANEL_VERSION = 2 as const
+
+interface PanelProps {
+  /** Visible heading. */
+  title: string
+  tone?: PanelTone
+  count?: number
+}
+
+interface PanelEmits {
+  (event: 'close'): void
+  (event: 'select', id: number): void
+}
+
+interface PanelSlots {
+  default: () => unknown
+  header?: (props: { title: string }) => unknown
+}
+
+const props = withDefaults(defineProps<PanelProps>(), {
+  tone: 'neutral',
+  count: 0,
+})
+const emit = defineEmits<PanelEmits>()
+const slots = defineSlots<PanelSlots>()
+const close = () => emit('close')
+defineExpose({ close })
+</script>
+
+<section data-tone="{{ props.tone }}">
+  <slot name="header" :title="props.title"></slot>
+  <slot></slot>
+</section>

--- a/packages/dtsx/test/fixtures/stx/types.ts
+++ b/packages/dtsx/test/fixtures/stx/types.ts
@@ -1,0 +1,6 @@
+export type PanelTone = 'neutral' | 'brand' | 'danger'
+
+export interface BadgeMeta {
+  id: string
+  tags: readonly string[]
+}

--- a/packages/dtsx/test/stx.test.ts
+++ b/packages/dtsx/test/stx.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { cp, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { generate } from '../src/generator'
+import { processSource } from '../src/process-source'
+import { isStxFile, parseStxScripts, transformStxToTs } from '../src/stx'
+
+const fixturesDir = join(import.meta.dir, 'fixtures', 'stx')
+const tempDirs: string[] = []
+
+async function createTempDir(): Promise<string> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'dtsx-stx-'))
+  tempDirs.push(tempDir)
+  return tempDir
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })))
+})
+
+const stxShim = `declare module '@stacksjs/stx' {
+  export type DefineComponent<Props = {}, RawBindings = {}, Data = unknown> = {
+    new (...args: unknown[]): { $props: Props }
+    props?: Props
+    setup?: (props: Props) => RawBindings | void
+    data?: Data
+  }
+}
+`
+
+async function expectParsesUnderTsc(dts: string, dependencies: Record<string, string> = {}): Promise<void> {
+  const tempDir = await createTempDir()
+  await writeFile(join(tempDir, 'out.d.ts'), dts)
+  await writeFile(join(tempDir, 'stx.d.ts'), stxShim)
+  await Promise.all(Object.entries(dependencies).map(([name, content]) => writeFile(join(tempDir, name), content)))
+  const tscBin = join(import.meta.dir, '..', '..', '..', 'node_modules', '.bin', 'tsc')
+  const proc = Bun.spawnSync([tscBin, '--noEmit', '--strict', 'out.d.ts', 'stx.d.ts', ...Object.keys(dependencies)], { cwd: tempDir })
+  const output = `${proc.stdout.toString()}${proc.stderr.toString()}`
+  expect(proc.exitCode === 0 ? '' : output).toBe('')
+}
+
+async function generateFixtures(entrypoints: string[], isolatedDeclarations: boolean): Promise<string> {
+  const tempDir = await createTempDir()
+  const srcDir = join(tempDir, 'src')
+  const outDir = join(tempDir, 'dist')
+  await cp(fixturesDir, srcDir, { recursive: true })
+  await generate({
+    cwd: tempDir,
+    root: './src',
+    outdir: './dist',
+    entrypoints,
+    isolatedDeclarations,
+    clean: true,
+  })
+  return outDir
+}
+
+describe('stx component parsing', () => {
+  it('detects only terminal .stx extensions', () => {
+    expect(isStxFile('/src/Panel.stx')).toBe(true)
+    expect(isStxFile('/src/Panel.ts')).toBe(false)
+    expect(isStxFile('/src/Panel.stx.ts')).toBe(false)
+    expect(isStxFile('/src/Panel.STX')).toBe(false)
+  })
+
+  it('collects server, client, universal and Blade TypeScript blocks in document order', () => {
+    const source = [
+      '@ts',
+      'export type First = string',
+      '@endts',
+      '<script server lang="ts">export const second = 2</script>',
+      '<script client type="text/typescript">export const third = 3</script>',
+      '<script>export const fourth = 4</script>',
+    ].join('\n')
+    const blocks = parseStxScripts(source)
+    expect(blocks.map(block => block.kind)).toEqual(['ts', 'script', 'script', 'script'])
+    expect(blocks.map(block => block.context)).toEqual(['universal', 'server', 'client', 'universal'])
+    expect(blocks.map(block => block.lang)).toEqual(['ts', 'ts', 'ts', 'js'])
+    expect(blocks.map(block => block.content.trim())).toEqual([
+      'export type First = string',
+      'export const second = 2',
+      'export const third = 3',
+      'export const fourth = 4',
+    ])
+  })
+
+  it('does not close a Blade block for @endts text inside its code', () => {
+    const source = `@ts\nconst marker = '@endts'\nexport interface Props { value: string }\nconst props = {} as Props\n@endts\n<div />`
+    const blocks = parseStxScripts(source)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].content).toContain(`const marker = '@endts'`)
+    expect(blocks[0].content).toContain('interface Props')
+  })
+
+  it('keeps an unfinished Blade block usable while a file is being edited', () => {
+    const blocks = parseStxScripts('@ts\nexport interface Props { value: string }')
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].content).toContain('interface Props')
+  })
+
+  it('ignores directive-looking text in plain runtime script strings', () => {
+    const source = `<script>\nconst docs = \`export default { props: ['fake'] }\`\n</script>`
+    const dts = processSource(source, 'RuntimeDocs.stx')
+    expect(dts).toContain('DefineComponent<{}>')
+    expect(dts).not.toContain('fake?: unknown')
+  })
+})
+
+describe('stx component declaration transform', () => {
+  it('declares modern STX props, emits, slots, exposed values and named exports', async () => {
+    const source = await readFile(join(fixturesDir, 'TypedPanel.stx'), 'utf8')
+    const dts = processSource(source, 'TypedPanel.stx')
+    expect(dts).toContain(`import type { DefineComponent } from '@stacksjs/stx';`)
+    expect(dts).toContain(`import type { PanelTone } from './types';`)
+    expect(dts).toContain('title: string')
+    expect(dts).toContain('tone?: PanelTone')
+    expect(dts).toContain('count?: number')
+    expect(dts).toContain('readonly __stxEmits?')
+    expect(dts).toContain(`(event: 'select', id: number): void`)
+    expect(dts).toContain('readonly __stxSlots?: PanelSlots')
+    expect(dts).toContain('readonly __stxExposed?')
+    expect(dts).toContain('PANEL_VERSION')
+    expect(dts).not.toContain('defineProps')
+    expect(dts).not.toContain('withDefaults')
+    expect(dts).not.toContain('declare const props')
+    expect(dts).toContain('declare const close: () => unknown')
+  })
+
+  it('declares Blade-style props assertions without leaking render helpers', async () => {
+    const source = await readFile(join(fixturesDir, 'BladeAlert.stx'), 'utf8')
+    const dts = processSource(source, 'BladeAlert.stx')
+    expect(dts).toContain(`export declare interface AlertProps`)
+    expect(dts).toContain(`DefineComponent<AlertProps>`)
+    expect(dts).not.toContain('getAlertClass')
+    expect(dts).not.toContain('declare const type')
+    await expectParsesUnderTsc(dts)
+  })
+
+  it('maps STX options-style runtime props', async () => {
+    const source = await readFile(join(fixturesDir, 'OptionsBadge.stx'), 'utf8')
+    const dts = processSource(source, 'OptionsBadge.stx')
+    expect(dts).toContain('label: string')
+    expect(dts).toContain('count?: number')
+    expect(dts).toContain('active?: boolean')
+    expect(dts).toContain('meta?: BadgeMeta')
+    expect(dts).not.toContain('PropType')
+  })
+
+  it('merges Blade, client and server declarations in source order', async () => {
+    const source = await readFile(join(fixturesDir, 'MixedBlocks.stx'), 'utf8')
+    const dts = processSource(source, 'MixedBlocks.stx')
+    expect(dts).toContain(`export type ServerStatus = 'ready' | 'busy';`)
+    expect(dts).toContain(`STATUS_ATTRIBUTE`)
+    expect(dts).toContain('status: ServerStatus')
+    expect(dts).toContain('retries?: number')
+    expect(dts).not.toContain('declare const retries')
+  })
+
+  it('emits an empty STX component for template-only files', async () => {
+    const source = await readFile(join(fixturesDir, 'TemplateOnly.stx'), 'utf8')
+    const dts = processSource(source, 'TemplateOnly.stx')
+    expect(dts).toContain('DefineComponent<{}>')
+    expect(dts).toContain('export default __dtsx_component__;')
+    await expectParsesUnderTsc(dts)
+  })
+
+  it('supports inline object props and typed $props annotations', () => {
+    const inline = processSource(`@ts\nconst local = props as { id: string; nested?: { count: number } }\n@endts`, 'Inline.stx')
+    expect(inline).toContain('id: string')
+    expect(inline).toContain('nested?: { count: number }')
+
+    const annotation = processSource(`@ts\nimport type { ExternalProps } from './external'\ndeclare const $props: ExternalProps\n@endts`, 'Annotated.stx')
+    expect(annotation).toContain('DefineComponent<ExternalProps>')
+    expect(annotation).toContain(`from './external'`)
+  })
+
+  it('infers legacy Blade-style $props access with useful default-value types', async () => {
+    const source = `<script server>
+export const title = $props.title || 'Untitled'
+export const count = $props.count ?? 0
+export const enabled = $props.enabled !== false
+export const items = $props.items || []
+export const metadata = $props['metadata'] || {}
+export const opaque = $props.value
+</script>`
+    const dts = processSource(source, 'LegacyProps.stx')
+    expect(dts).toContain('title?: string')
+    expect(dts).toContain('count?: number')
+    expect(dts).toContain('enabled?: boolean')
+    expect(dts).toContain('items?: unknown[]')
+    expect(dts).toContain('metadata?: Record<string, unknown>')
+    expect(dts).toContain('value?: unknown')
+    await expectParsesUnderTsc(dts)
+  })
+
+  it('ignores $props examples in comments and strings while preserving Unicode offsets', () => {
+    const source = `<script server>
+const emoji = '🔥 $props.fake'
+// $props.commented
+export const label = $props.label || 'Label'
+</script>`
+    const dts = processSource(source, 'UnicodeProps.stx')
+    expect(dts).toContain('label?: string')
+    expect(dts).not.toContain('fake?:')
+    expect(dts).not.toContain('commented?:')
+  })
+
+  it('always declares components whose client scripts begin with runtime expressions', () => {
+    const iife = processSource(`<script client>\n(() => { const ready = true })()\n</script>`, 'Iife.stx')
+    const browserCall = processSource(`<script client>\nwindow.addEventListener('ready', () => {})\n</script>`, 'BrowserCall.stx')
+    expect(iife).toContain('export default __dtsx_component__;')
+    expect(browserCall).toContain('export default __dtsx_component__;')
+  })
+
+  it('handles comments and nested generic types without corrupting declarations', async () => {
+    const source = `<script server lang="ts">
+defineProps<{
+  /** Values grouped by key. */
+  groups: ReadonlyMap<string, Array<{ id: string; run: () => Promise<void> }>>
+  label?: string // accessible label
+}>()
+</script>`
+    const dts = processSource(source, 'Nested.stx')
+    expect(dts).toContain('ReadonlyMap<string, Array<{ id: string; run: () => Promise<void> }>>')
+    expect(dts).toContain('/* accessible label */')
+    expect(dts).not.toMatch(/\*\/;/)
+    await expectParsesUnderTsc(dts)
+  })
+
+  it('produces equivalent public contracts in semantic and isolated modes', async () => {
+    const source = await readFile(join(fixturesDir, 'TypedPanel.stx'), 'utf8')
+    const semantic = processSource(source, 'TypedPanel.stx', true, ['bun'], false)
+    const isolated = processSource(source, 'TypedPanel.stx', true, ['bun'], true)
+    for (const expected of ['title: string', 'tone?: PanelTone', '__stxEmits', '__stxSlots', 'PANEL_VERSION']) {
+      expect(semantic).toContain(expected)
+      expect(isolated).toContain(expected)
+    }
+    expect(isolated).toContain('export default __dtsx_component__;')
+  })
+
+  it('returns a plain default-export script unchanged', () => {
+    const virtual = transformStxToTs(`<script>\nconst component = class Card {}\nexport default component\n</script>`)
+    expect(virtual).toContain('export default component')
+    expect(virtual).not.toContain('__dtsx_component__')
+  })
+})
+
+describe('stx project generation', () => {
+  for (const isolatedDeclarations of [false, true]) {
+    it(`emits and typechecks STX entrypoints in ${isolatedDeclarations ? 'isolated' : 'semantic'} mode`, async () => {
+      const outDir = await generateFixtures(['**/*.{stx,ts}'], isolatedDeclarations)
+      const panel = await readFile(join(outDir, 'TypedPanel.d.ts'), 'utf8')
+      const blade = await readFile(join(outDir, 'BladeAlert.d.ts'), 'utf8')
+      const options = await readFile(join(outDir, 'OptionsBadge.d.ts'), 'utf8')
+      const mixed = await readFile(join(outDir, 'MixedBlocks.d.ts'), 'utf8')
+      const template = await readFile(join(outDir, 'TemplateOnly.d.ts'), 'utf8')
+      const types = await readFile(join(outDir, 'types.d.ts'), 'utf8')
+
+      expect(panel).toContain('title: string')
+      expect(blade).toContain('DefineComponent<AlertProps>')
+      expect(options).toContain('meta?: BadgeMeta')
+      expect(mixed).toContain('status: ServerStatus')
+      expect(template).toContain('DefineComponent<{}>')
+      expect(types).toContain('PanelTone')
+
+      await expectParsesUnderTsc(panel, {
+        'types.d.ts': types,
+      })
+    })
+  }
+
+  it('discovers .stx files through default entrypoints', async () => {
+    const tempDir = await createTempDir()
+    await cp(fixturesDir, join(tempDir, 'src'), { recursive: true })
+    await generate({ cwd: tempDir, root: './src', outdir: './dist', clean: true })
+    expect(await readFile(join(tempDir, 'dist', 'TypedPanel.d.ts'), 'utf8')).toContain('title: string')
+  })
+
+  it('auto-includes and rewrites explicitly imported .stx components', async () => {
+    const tempDir = await createTempDir()
+    const srcDir = join(tempDir, 'src')
+    const outDir = join(tempDir, 'dist')
+    await cp(fixturesDir, srcDir, { recursive: true })
+    await writeFile(join(srcDir, 'index.ts'), `import TypedPanel from './TypedPanel.stx'\nexport { TypedPanel }\n`)
+    await generate({ cwd: tempDir, root: './src', outdir: './dist', entrypoints: ['index.ts'], clean: true })
+
+    const index = await readFile(join(outDir, 'index.d.ts'), 'utf8')
+    expect(index).toContain(`from './TypedPanel'`)
+    expect(index).not.toContain('.stx')
+    expect(await readFile(join(outDir, 'TypedPanel.d.ts'), 'utf8')).toContain('title: string')
+  })
+
+  it('resolves extensionless imports to STX components', async () => {
+    const tempDir = await createTempDir()
+    const srcDir = join(tempDir, 'src')
+    const outDir = join(tempDir, 'dist')
+    await cp(fixturesDir, srcDir, { recursive: true })
+    await writeFile(join(srcDir, 'index.ts'), `export { default as TemplateOnly } from './TemplateOnly'\n`)
+    await generate({ cwd: tempDir, root: './src', outdir: './dist', entrypoints: ['index.ts'], clean: true })
+
+    expect(await readFile(join(outDir, 'index.d.ts'), 'utf8')).toContain(`from './TemplateOnly'`)
+    expect(await readFile(join(outDir, 'TemplateOnly.d.ts'), 'utf8')).toContain('DefineComponent<{}>')
+  })
+})


### PR DESCRIPTION
## Summary

- generate first-class declarations for STX Vue-style script components and Blade-style `@ts` components
- derive props from `defineProps`, runtime prop schemas, `props as Props`, and legacy `$props.name` access
- retain typed emits, slots, exposed values, named exports, and strict `@stacksjs/stx` component contracts
- discover, watch, auto-include, emit, and rewrite `.stx` entrypoints
- harden shared SFC scanning around strings, nested setup values, `defineSlots`, and shorthand exposed values

## Impact

STX component consumers now receive useful generated `.d.ts` files through both the semantic inference path and the annotation-first isolated-declarations path. Existing STX component libraries using legacy `$props` syntax also gain inferred public prop contracts without source migrations.

## Validation

- `bun run test` — 1,611 passed
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `zig build test` in `packages/zig-dtsx`
- focused STX/Vue suite with strict `tsc` declaration consumption
- all 514 `.stx` files in `~/Code/Tools/stx` processed successfully in semantic and isolated modes
