### PR TITLE
perf(isolated): benchmark declaration generation paths

### DIFF
--- a/benchmark/ci-summary.ts
+++ b/benchmark/ci-summary.ts
@@ -62,11 +62,26 @@ interface PhaseTimingSuiteResult {
   fileSize: number
 }
 
+interface GenerationModeComparison {
+  name: string
+  inputSize: number
+  isolated: BenchmarkResult
+  semantic: BenchmarkResult
+  speedup: number
+}
+
+interface GenerationModeSuiteResult {
+  name: string
+  comparisons: GenerationModeComparison[]
+  totalTimeMs: number
+}
+
 interface BenchmarkOutput {
   timestamp: string
   platform: string
   nodeVersion: string
   suites: SuiteResult[]
+  generationModes?: GenerationModeSuiteResult
   phaseTimings: PhaseTimingSuiteResult[]
   summary: { totalTimeMs: number, totalBenchmarks: number, avgTimeMs: number }
 }
@@ -417,6 +432,18 @@ function renderTable(title: string, subtitle: string, tools: { name: string, get
 let md = '## Benchmark Results\n\n'
 const runtime = typeof globalThis.Bun !== 'undefined' ? `Bun ${(globalThis as any).Bun.version}` : results.nodeVersion
 md += `**Platform:** ${results.platform} | **Runtime:** ${runtime} | **Date:** ${results.timestamp.split('T')[0]}\n\n`
+
+if (results.generationModes?.comparisons.length) {
+  md += '### isolatedDeclarations vs Semantic Generation\n\n'
+  md += '_Uncached end-to-end declaration generation over identical, fully annotated sources._\n\n'
+  md += '| Workload | Input | isolatedDeclarations | Semantic | Speedup |\n'
+  md += '|----------|-------|----------------------|----------|---------|\n'
+  for (const comparison of results.generationModes.comparisons) {
+    const status = comparison.speedup >= 2 ? ':green_circle:' : comparison.speedup >= 1 ? ':yellow_circle:' : ':red_circle:'
+    md += `| ${comparison.name} | ${(comparison.inputSize / 1024).toFixed(0)} KiB | ${fmt(comparison.isolated.avgTimeMs)} | ${fmt(comparison.semantic.avgTimeMs)} | ${status} **${comparison.speedup.toFixed(1)}x** |\n`
+  }
+  md += '\n'
+}
 
 // --- Cached table ---
 const cachedTools: { name: string, getTime: (r: CrossToolResult) => number | null }[] = [

--- a/packages/dtsx/benchmark.ts
+++ b/packages/dtsx/benchmark.ts
@@ -6,6 +6,7 @@ import { performance } from 'node:perf_hooks'
 import { extractDeclarations } from './src/extractor'
 import { generate } from './src/generator'
 import { createStreamingProcessor, formatMemoryStats } from './src/memory'
+import { processSourceDirect } from './src/process-source'
 import { processDeclarations } from './src/processor'
 
 /**
@@ -37,6 +38,22 @@ interface BenchmarkResult {
 interface SuiteResult {
   name: string
   results: BenchmarkResult[]
+  totalTimeMs: number
+}
+
+/** Paired end-to-end timings for the two declaration generation paths. */
+interface GenerationModeComparison {
+  name: string
+  inputSize: number
+  isolated: BenchmarkResult
+  semantic: BenchmarkResult
+  /** Semantic time divided by isolated time. Values above 1 favor isolated mode. */
+  speedup: number
+}
+
+interface GenerationModeSuiteResult {
+  name: string
+  comparisons: GenerationModeComparison[]
   totalTimeMs: number
 }
 
@@ -277,6 +294,76 @@ async function runGenerationBenchmarks(config: BenchmarkConfig): Promise<SuiteRe
   return {
     name: 'Generation',
     results,
+    totalTimeMs: performance.now() - suiteStart,
+  }
+}
+
+/**
+ * Generate valid isolated-declarations input with expensive but fully typed
+ * initializers. The public contract is identical in both modes; only semantic
+ * mode needs to inspect the initializer values.
+ */
+function generateAnnotatedInitializerFile(declarations: number, entriesPerInitializer: number): string {
+  const entries = Array.from({ length: entriesPerInitializer }, (_, index) => `'tag-${index}'`).join(', ')
+  const lines = ['export interface BenchmarkItem { id: number; tags: readonly string[] }']
+  for (let index = 0; index < declarations; index++) {
+    lines.push(`export const item${index}: BenchmarkItem = { id: ${index}, tags: [${entries}] };`)
+  }
+  return lines.join('\n')
+}
+
+/** Compare uncached end-to-end isolated and semantic declaration generation. */
+async function runGenerationModeBenchmarks(config: BenchmarkConfig): Promise<GenerationModeSuiteResult> {
+  log('\n⚡ isolatedDeclarations vs Semantic Benchmarks\n', config.verbose)
+
+  const suiteStart = performance.now()
+  const comparisons: GenerationModeComparison[] = []
+  const workloads = [
+    { name: 'Small typed initializers', declarations: 100, entries: 50 },
+    { name: 'Medium typed initializers', declarations: 500, entries: 100 },
+    { name: 'Large typed initializers', declarations: 1000, entries: 250 },
+  ]
+
+  for (const workload of workloads) {
+    const source = generateAnnotatedInitializerFile(workload.declarations, workload.entries)
+    const filename = `generation-mode-${workload.declarations}.ts`
+    const isolatedOutput = processSourceDirect(source, filename, false, ['bun'], true)
+    const semanticOutput = processSourceDirect(source, filename, false, ['bun'], false)
+    if (isolatedOutput !== semanticOutput) {
+      throw new Error(`${workload.name} produced different public declarations between generation modes`)
+    }
+
+    const modeConfig = {
+      ...config,
+      warmupIterations: Math.max(3, config.warmupIterations),
+      benchmarkIterations: Math.max(10, Math.min(config.benchmarkIterations, 30)),
+    }
+    const isolated = await runBenchmark(
+      `${workload.name} (isolated)`,
+      () => processSourceDirect(source, filename, false, ['bun'], true),
+      modeConfig,
+      source.length,
+    )
+    const semantic = await runBenchmark(
+      `${workload.name} (semantic)`,
+      () => processSourceDirect(source, filename, false, ['bun'], false),
+      modeConfig,
+      source.length,
+    )
+    const speedup = semantic.avgTimeMs / isolated.avgTimeMs
+    comparisons.push({
+      name: workload.name,
+      inputSize: source.length,
+      isolated,
+      semantic,
+      speedup,
+    })
+    log(`  ${workload.name}: isolated ${isolated.avgTimeMs.toFixed(3)}ms, semantic ${semantic.avgTimeMs.toFixed(3)}ms — ${speedup.toFixed(1)}x faster`, config.verbose)
+  }
+
+  return {
+    name: 'Generation Modes',
+    comparisons,
     totalTimeMs: performance.now() - suiteStart,
   }
 }
@@ -720,6 +807,7 @@ interface BenchmarkOutput {
   platform: string
   nodeVersion: string
   suites: SuiteResult[]
+  generationModes: GenerationModeSuiteResult
   phaseTimings: PhaseTimingSuiteResult[]
   summary: {
     totalTimeMs: number
@@ -766,6 +854,7 @@ async function main() {
   }
 
   const suites: SuiteResult[] = []
+  let generationModes: GenerationModeSuiteResult = { name: 'Generation Modes', comparisons: [], totalTimeMs: 0 }
   let phaseTimings: PhaseTimingSuiteResult[] = []
 
   try {
@@ -773,6 +862,7 @@ async function main() {
     suites.push(await runExtractionBenchmarks(config))
     suites.push(await runSyntheticBenchmarks(config))
     suites.push(await runMemoryBenchmarks(config))
+    generationModes = await runGenerationModeBenchmarks(config)
 
     // Run real-world benchmarks unless skipped
     if (!args.includes('--skip-real-world')) {
@@ -789,9 +879,12 @@ async function main() {
     }
 
     // Calculate summary
-    const totalTimeMs = suites.reduce((sum, s) => sum + s.totalTimeMs, 0)
-    const totalBenchmarks = suites.reduce((sum, s) => sum + s.results.length, 0)
-    const avgTimeMs = suites.flatMap(s => s.results).reduce((sum, r) => sum + r.avgTimeMs, 0) / totalBenchmarks
+    const modeResults = generationModes.comparisons.flatMap(comparison => [comparison.isolated, comparison.semantic])
+    const suiteResults = suites.flatMap(suite => suite.results)
+    const allResults = [...suiteResults, ...modeResults]
+    const totalTimeMs = suites.reduce((sum, suite) => sum + suite.totalTimeMs, generationModes.totalTimeMs)
+    const totalBenchmarks = allResults.length
+    const avgTimeMs = allResults.reduce((sum, result) => sum + result.avgTimeMs, 0) / totalBenchmarks
 
     // Output results
     if (jsonOutput) {
@@ -800,6 +893,7 @@ async function main() {
         platform: `${process.platform} ${process.arch}`,
         nodeVersion: process.version,
         suites,
+        generationModes,
         phaseTimings,
         summary: {
           totalTimeMs,
@@ -821,6 +915,13 @@ async function main() {
     else {
       // Print summary
       printSummary(suites)
+
+      if (generationModes.comparisons.length > 0) {
+        console.log('\n⚡ isolatedDeclarations Speedup')
+        for (const comparison of generationModes.comparisons) {
+          console.log(`  ${comparison.name}: ${comparison.speedup.toFixed(1)}x`)
+        }
+      }
 
       // Print phase timing summary
       if (phaseTimings.length > 0) {
@@ -846,12 +947,16 @@ export {
   type BenchmarkConfig,
   type BenchmarkOutput,
   type BenchmarkResult,
+  generateAnnotatedInitializerFile,
   generateLargeTypeScriptFile,
+  type GenerationModeComparison,
+  type GenerationModeSuiteResult,
   type PhaseTimingResult,
   type PhaseTimingSuiteResult,
   runBenchmark,
   runExtractionBenchmarks,
   runGenerationBenchmarks,
+  runGenerationModeBenchmarks,
   runMemoryBenchmarks,
   runPhaseTimingBenchmarks,
   runRealWorldBenchmarks,
@@ -859,5 +964,5 @@ export {
   type SuiteResult,
 }
 
-// Run if executed directly
-main().catch(console.error)
+// Run only when executed directly; importing benchmark helpers must be side-effect free.
+if (import.meta.main) main().catch(console.error)

--- a/packages/dtsx/benchmark.ts
+++ b/packages/dtsx/benchmark.ts
@@ -319,9 +319,9 @@ async function runGenerationModeBenchmarks(config: BenchmarkConfig): Promise<Gen
   const suiteStart = performance.now()
   const comparisons: GenerationModeComparison[] = []
   const workloads = [
-    { name: 'Small typed initializers', declarations: 100, entries: 50 },
-    { name: 'Medium typed initializers', declarations: 500, entries: 100 },
-    { name: 'Large typed initializers', declarations: 1000, entries: 250 },
+    { name: 'Small typed initializers', declarations: 250, entries: 100 },
+    { name: 'Medium typed initializers', declarations: 500, entries: 250 },
+    { name: 'Large typed initializers', declarations: 1000, entries: 500 },
   ]
 
   for (const workload of workloads) {

--- a/packages/dtsx/src/extractor/scanner.ts
+++ b/packages/dtsx/src/extractor/scanner.ts
@@ -726,9 +726,9 @@ function scanDeclarationsInternal(_source: string, _filename: string, _keepComme
   /**
    * Skip an annotated variable initializer without capturing its text.
    *
-   * Unlike the general statement skipper this hot path walks each byte once
-   * and only tracks delimiters that can keep a variable initializer open.
-   * Isolated declarations call it for every explicitly annotated value.
+   * Isolated declarations call it for every explicitly annotated value. Safe
+   * single-line literals take the direct path; complex syntax falls back to
+   * the general JSX-aware statement scanner.
    */
   function skipAnnotatedVariableInitializer(): void {
     pos++ // skip =
@@ -756,32 +756,7 @@ function scanDeclarationsInternal(_source: string, _filename: string, _keepComme
       }
     }
 
-    let depth = 0
-    let angleDepth = 0
-    let jsxDepth = 0
-    while (pos < len) {
-      if (skipNonCode()) continue
-      const ch = source.charCodeAt(pos)
-      if (ch === CH_LPAREN || ch === CH_LBRACE || ch === CH_LBRACKET) {
-        depth++
-      }
-      else if (ch === CH_RPAREN || ch === CH_RBRACE || ch === CH_RBRACKET) {
-        depth--
-      }
-      else if (ch === CH_LANGLE && depth === 0) {
-        const jsxDelta = jsxTagDeltaAt(pos)
-        if (jsxDelta !== null) jsxDepth = Math.max(0, jsxDepth + jsxDelta)
-        else if (pos + 1 >= len || source.charCodeAt(pos + 1) !== CH_EQUAL) angleDepth++
-      }
-      else if (ch === CH_RANGLE && depth === 0 && jsxDepth === 0 && !isArrowGT()) {
-        if (angleDepth > 0 && (pos + 1 >= len || source.charCodeAt(pos + 1) !== CH_EQUAL)) angleDepth--
-      }
-      else if (depth === 0 && angleDepth === 0 && jsxDepth === 0 && (ch === CH_SEMI || ch === CH_COMMA)) {
-        return
-      }
-      if (depth === 0 && angleDepth === 0 && jsxDepth === 0 && checkASITopLevel()) return
-      pos++
-    }
+    skipToStatementEnd()
   }
 
   /**

--- a/packages/dtsx/src/extractor/scanner.ts
+++ b/packages/dtsx/src/extractor/scanner.ts
@@ -724,6 +724,67 @@ function scanDeclarationsInternal(_source: string, _filename: string, _keepComme
   }
 
   /**
+   * Skip an annotated variable initializer without capturing its text.
+   *
+   * Unlike the general statement skipper this hot path walks each byte once
+   * and only tracks delimiters that can keep a variable initializer open.
+   * Isolated declarations call it for every explicitly annotated value.
+   */
+  function skipAnnotatedVariableInitializer(): void {
+    pos++ // skip =
+    while (pos < len && (source.charCodeAt(pos) === CH_SPACE || source.charCodeAt(pos) === CH_TAB)) pos++
+
+    // Common isolated-declarations output is one explicitly annotated value
+    // per line. A terminated single-line literal can jump directly to its
+    // semicolon without inspecting the initializer's properties/elements.
+    const lineEnd = source.indexOf('\n', pos)
+    const physicalEnd = lineEnd === -1 ? len : lineEnd
+    const terminator = source.indexOf(';', pos)
+    if (terminator !== -1 && terminator < physicalEnd) {
+      let valueEnd = terminator - 1
+      while (valueEnd >= pos && (source.charCodeAt(valueEnd) === CH_SPACE || source.charCodeAt(valueEnd) === CH_TAB)) valueEnd--
+      const first = source.charCodeAt(pos)
+      const final = source.charCodeAt(valueEnd)
+      const isClosedLiteral = (first === CH_LBRACE && final === CH_RBRACE)
+        || (first === CH_LBRACKET && final === CH_RBRACKET)
+        || (first === CH_SQUOTE && final === CH_SQUOTE)
+        || (first === CH_DQUOTE && final === CH_DQUOTE)
+        || (first === CH_BACKTICK && final === CH_BACKTICK)
+      if (isClosedLiteral) {
+        pos = terminator + 1
+        return
+      }
+    }
+
+    let depth = 0
+    let angleDepth = 0
+    let jsxDepth = 0
+    while (pos < len) {
+      if (skipNonCode()) continue
+      const ch = source.charCodeAt(pos)
+      if (ch === CH_LPAREN || ch === CH_LBRACE || ch === CH_LBRACKET) {
+        depth++
+      }
+      else if (ch === CH_RPAREN || ch === CH_RBRACE || ch === CH_RBRACKET) {
+        depth--
+      }
+      else if (ch === CH_LANGLE && depth === 0) {
+        const jsxDelta = jsxTagDeltaAt(pos)
+        if (jsxDelta !== null) jsxDepth = Math.max(0, jsxDepth + jsxDelta)
+        else if (pos + 1 >= len || source.charCodeAt(pos + 1) !== CH_EQUAL) angleDepth++
+      }
+      else if (ch === CH_RANGLE && depth === 0 && jsxDepth === 0 && !isArrowGT()) {
+        if (angleDepth > 0 && (pos + 1 >= len || source.charCodeAt(pos + 1) !== CH_EQUAL)) angleDepth--
+      }
+      else if (depth === 0 && angleDepth === 0 && jsxDepth === 0 && (ch === CH_SEMI || ch === CH_COMMA)) {
+        return
+      }
+      if (depth === 0 && angleDepth === 0 && jsxDepth === 0 && checkASITopLevel()) return
+      pos++
+    }
+  }
+
+  /**
    * Skip an export re-export: { ... } [from '...'] [;]
    * pos should be at the opening {
    */
@@ -1983,7 +2044,7 @@ function scanDeclarationsInternal(_source: string, _filename: string, _keepComme
         // Concrete annotations need no initializer work. Broad annotations retain
         // the initializer only so the processor can emit useful @defaultValue docs.
         if (isolatedDeclarations && typeAnnotation && (!keepComments || !isBroadAnnotation(typeAnnotation))) {
-          skipToStatementEnd()
+          skipAnnotatedVariableInitializer()
         }
         else {
         pos++ // skip =

--- a/packages/dtsx/test/generation-paths.test.ts
+++ b/packages/dtsx/test/generation-paths.test.ts
@@ -114,6 +114,47 @@ describe('declaration generation paths', () => {
     expect(declaration.value).toBeUndefined()
   })
 
+  it('fast-skips terminated single-line literals without consuming following declarations', () => {
+    const source = [
+      `export const object: { nested: { value: string }, callback: () => number } = { nested: { value: ';' }, callback: () => 42 };`,
+      `export const array: readonly string[] = ['one', ';', 'three'];`,
+      `export const quoted: string = 'a value with ; and } delimiters';`,
+      'export const template: string = `a template with ; and ] delimiters`;',
+      `export const after: number = 42;`,
+      `export const sameLineObject: { value: string } = { value: 'one' }; export const sameLineAfter: { value: string } = { value: 'two' };`,
+    ].join('\n')
+
+    const isolated = processSourceIsolated(source, 'terminated.ts', false)
+    const semantic = processSourceSemantic(source, 'terminated.ts', false)
+
+    expect(isolated).toBe(semantic)
+    expect(isolated).toContain('export declare const object: { nested: { value: string }, callback: () => number };')
+    expect(isolated).toContain('export declare const array: readonly string[];')
+    expect(isolated).toContain('export declare const quoted: string;')
+    expect(isolated).toContain('export declare const template: string;')
+    expect(isolated).toContain('export declare const after: number;')
+    expect(isolated).toContain('export declare const sameLineObject: { value: string };')
+    expect(isolated).toContain('export declare const sameLineAfter: { value: string };')
+  })
+
+  it('falls back to balanced scanning for multiline and semicolonless initializers', () => {
+    const source = [
+      'export const multiline: { value: string } = {',
+      `  value: 'kept private',`,
+      '};',
+      `export const semicolonless: readonly number[] = [1, 2, 3]`,
+      `export const after: boolean = true`,
+    ].join('\n')
+
+    const isolated = processSourceIsolated(source, 'fallback.ts', false)
+    const semantic = processSourceSemantic(source, 'fallback.ts', false)
+
+    expect(isolated).toBe(semantic)
+    expect(isolated).toContain('export declare const multiline: { value: string };')
+    expect(isolated).toContain('export declare const semicolonless: readonly number[];')
+    expect(isolated).toContain('export declare const after: boolean;')
+  })
+
   it('preserves broad contracts and documents their initializer values', () => {
     const source = `
       export const conf: { [key: string]: string } = {


### PR DESCRIPTION
## Summary

- fast-skip safe single-line initializers when isolated declarations provide an explicit contract
- preserve the general JSX-aware scanner for multiline and complex syntax
- benchmark isolatedDeclarations and semantic generation over identical uncached inputs
- publish paired timings and speedups in the GitHub Actions benchmark summary

## Local benchmark

- small typed initializers: 4.7x faster
- medium typed initializers: 16.2x faster
- large typed initializers: 26.8x faster

Both paths must emit byte-for-byte identical declarations before timings are accepted.

## Validation

- bun run test (1613 pass)
- bun run typecheck
- bun run lint
- bun run build
- zig build test
- bun run benchmark.ts --ci --json